### PR TITLE
[IAM-2148] fix breaking route changes

### DIFF
--- a/lib/doorkeeper/rails/routes.rb
+++ b/lib/doorkeeper/rails/routes.rb
@@ -47,7 +47,7 @@ module Doorkeeper
           as: mapping[:as],
           controller: mapping[:controllers]
         ) do
-          routes.get '/native', action: :show, on: :member
+          routes.get '/:code', action: :show, on: :member
           routes.get '/', action: :new, on: :member
         end
       end

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -154,7 +154,7 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
 
     it 'should redirect immediately' do
       expect(response).to be_redirect
-      expect(response.location).to match(/oauth\/authorize\/native\?code=#{Doorkeeper::AccessGrant.first.token}/)
+      expect(response.location).to match(/oauth\/authorize\//)
     end
 
     it 'should issue a grant' do

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -154,7 +154,7 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
 
     it 'should redirect immediately' do
       expect(response).to be_redirect
-      expect(response.location).to match(/oauth\/authorize\//)
+      expect(response.location).to match(/oauth\/authorize\/#{Doorkeeper::AccessGrant.first.token}/)
     end
 
     it 'should issue a grant' do

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -29,7 +29,6 @@ feature 'Authorization Code Flow' do
 
     access_grant_should_exist_for(@client, @resource_owner)
 
-    url_should_have_param('code', Doorkeeper::AccessGrant.first.token)
     i_should_see 'Authorization code:'
     i_should_see Doorkeeper::AccessGrant.first.token
   end


### PR DESCRIPTION
### Summary

Removes the breaking api change for the native redirect flow for v4.4.2. Not planning on merging this PR but we will use this branch. This version contains the fix for https://nvd.nist.gov/vuln/detail/CVE-2018-1000211 . It was easier to fix the api change and update the gem then to implement the fix ourselves.


